### PR TITLE
Fix for versions specified in metadata.rb, if a lock isn't found

### DIFF
--- a/cookbook/cookbook.go
+++ b/cookbook/cookbook.go
@@ -547,12 +547,16 @@ func (cbv *CookbookVersion) getDependencies(g *depgraph.Graph, nodes map[string]
 				continue
 			}
 		}
+		found = false
 		for k, ec := range envConstraints {
 			if k == depCb.Name {
 				appendConstraint(&nodes[r].Meta.(*depMeta).constraint, ec)
+				found = true
 			}
 		}
-		// appendConstraint(&nodes[r].Meta.(*depMeta).constraint, c)
+		if found == false {
+			appendConstraint(&nodes[r].Meta.(*depMeta).constraint, c)
+		}
 
 		cbShelf[r] = depCb
 		depCbv := depCb.latestMultiConstraint(nodes[r].Meta.(*depMeta).constraint)


### PR DESCRIPTION
Fix for java import-

After importing the old pre-lock json, pre-internal gives-
```
Synchronizing Cookbooks:
...
  - java (8.5.0)
...
```

After updating to this version, it gives
```
Synchronizing Cookbooks:
...
  - java (4.3.0)
...
```

# Testing

[x] Update lock on a top-level cookbook, verify it pulls a newer release.
[x] Update lock to top-level cookbook, verify it pulls older release.
[x] Update env lock on dependent cookbook, verify it pulls newer release.
[x] Update env lock on dependent cookbook, verify it pulls older release.
[x] Update metadata.rb lock on dependent cookbook, verify it pulls newer release. (This PR)
[x] Update metadata.rb lock on dependent cookbook, verify it pulls older release. (This PR)
[x] Update env lock to non-existent version, verify it fails.
[x] Restore env lock to existent version, verify it recovers.
